### PR TITLE
fix: avoid interrupting sync when checking canRedo/canUndo

### DIFF
--- a/src/undo-plugin.ts
+++ b/src/undo-plugin.ts
@@ -187,15 +187,15 @@ export const undo: Command = (state, dispatch): boolean => {
     return false;
   }
 
+  if (!dispatch) {
+    return undoState.undoManager.canUndo();
+  }
+
   undoState.isUndoing.current = true;
   setTimeout(() => {
     undoState.isUndoing.current = false;
   }, 0);
-  if (dispatch) {
-    return undoState.undoManager.undo();
-  } else {
-    return undoState.undoManager.canUndo();
-  }
+  return undoState.undoManager.undo();
 };
 
 export const redo: Command = (state, dispatch): boolean => {
@@ -203,13 +203,14 @@ export const redo: Command = (state, dispatch): boolean => {
   if (!undoState) {
     return false;
   }
+
+  if (!dispatch) {
+    return undoState.undoManager.canRedo();
+  }
+
   undoState.isUndoing.current = true;
   setTimeout(() => {
     undoState.isUndoing.current = false;
   }, 0);
-  if (dispatch) {
-    return undoState.undoManager.redo();
-  } else {
-    return undoState.undoManager.canRedo();
-  }
+  return undoState.undoManager.redo();
 };


### PR DESCRIPTION

Closes https://github.com/loro-dev/loro-prosemirror/issues/39 


Inside the `undo` and `redo` ProseMirror command, when `dispatch` is `null`, `undoState.isUndoing.current` should _not_ be touched. Setting `undoState.isUndoing.current` will interrupt the syncing later [here](https://github.com/loro-dev/loro-prosemirror/blob/611e4ebe3dca5ba60404e1db70c59a941314957b/src/sync-plugin.ts#L98). 

The editor needs to check `canUndo` / `canRedo` frequently to decide whether to disable the undo/redo buttons, shown below:

<img width="1008" height="610" alt="CleanShot 2025-10-25 at 09 01 42@2x" src="https://github.com/user-attachments/assets/abcf819f-88fd-49a7-ad70-35d243fd199b" />

