### PR TITLE
fix: enable NPM OIDC publish

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: The version of node.js
     required: false
-    default: "20"
+    default: "24"
 
 runs:
   using: composite
@@ -14,7 +14,7 @@ runs:
       uses: pnpm/action-setup@v4
 
     - name: Setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,9 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     needs: [version]
     if: ${{ needs.version.outputs.release_created }}
     steps:
@@ -28,6 +31,4 @@ jobs:
       - name: Build
         run: pnpm build
       - name: Publish to NPM
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
   "dependencies": {
     "lib0": "^0.2.42"
   },
+  "files": [
+    "dist",
+    "src"
+  ],
   "peerDependencies": {
     "loro-crdt": "^1.4.0",
     "prosemirror-model": "^1.18.1",


### PR DESCRIPTION
This PR enables [NPM OIDC](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/) releasing since the previous token-based releasing won't work anymore [since November](https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/).

Changes to the CI workflow (this PR):

1. Update Node.js to v24 to use the latest NPM CLI
2. Remove `${{ secrets.NPM_TOKEN }}`
3. Add proper permissions 

Changes needed for the NPM website:

1. Go to https://www.npmjs.com/package/loro-prosemirror
2. Click settings
3. Update the config like this: <img width="1720" height="1198" alt="CleanShot 2025-10-29 at 11 43 24@2x" src="https://github.com/user-attachments/assets/18d47e0c-0885-4214-adb8-df5656e524e9" />