### PR TITLE
fix: ignore out-of-bounds positions

### DIFF
--- a/src/undo-plugin.ts
+++ b/src/undo-plugin.ts
@@ -6,14 +6,10 @@ import {
   Plugin,
   PluginKey,
   type StateField,
-  TextSelection,
 } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
-import {
-  convertPmSelectionToCursors,
-  cursorToAbsolutePosition,
-} from "./cursor-plugin";
-import { loroSyncPluginKey } from "./sync-plugin";
+import { convertPmSelectionToCursors } from "./cursor-plugin";
+import { loroSyncPluginKey, syncCursorsToPmSelection } from "./sync-plugin";
 import { configLoroTextStyle } from "./text-style";
 
 export interface LoroUndoPluginProps {
@@ -130,35 +126,13 @@ export const LoroUndoPlugin = (props: LoroUndoPluginProps): Plugin => {
           return;
         }
 
-        const anchor = meta.cursors[0] ?? null;
-        const focus = meta.cursors[1] ?? null;
+        const anchor: Cursor | undefined = meta.cursors[0];
+        const focus: Cursor | undefined = meta.cursors[1];
         if (anchor == null) {
           return;
         }
-
         setTimeout(() => {
-          try {
-            const anchorPos = cursorToAbsolutePosition(
-              anchor,
-              loroState.doc,
-              loroState.mapping,
-            )[0];
-            const focusPos =
-              focus &&
-              cursorToAbsolutePosition(
-                focus,
-                loroState.doc,
-                loroState.mapping,
-              )[0];
-            const selection = TextSelection.create(
-              view.state.doc,
-              anchorPos,
-              focusPos ?? undefined,
-            );
-            view.dispatch(view.state.tr.setSelection(selection));
-          } catch (e) {
-            console.error(e);
-          }
+          syncCursorsToPmSelection(view, anchor, focus);
         }, 0);
       });
       return {


### PR DESCRIPTION
This PR fixes the following issue:

Steps to reproduce:

```bash
git clone https://github.com/issueset/loro-prosemirror-crash-issue
cd loro-prosemirror-crash-issue
git checkout ocavue-update-import
pnpm install
pnpm run dev
```

Open http://localhost:5173/ in the browser and you can see the error 

```
Uncaught (in promise) RangeError: Position 3 out of range
    at _ResolvedPos.resolve (index.js:1045:19)
    at _ResolvedPos.resolveCached (index.js:1077:56)
    at _Node.resolve (index.js:1376:39)
    at _TextSelection.create (index.js:280:27)
    at sync-plugin.ts:242:39
```

 