### PR TITLE
refactor: fix circular dependency

### DIFF
--- a/src/cursor-plugin.ts
+++ b/src/cursor-plugin.ts
@@ -21,7 +21,7 @@ import {
   type LoroNodeMapping,
   WEAK_NODE_TO_LORO_CONTAINER_MAPPING,
 } from "./lib";
-import { loroSyncPluginKey, type LoroSyncPluginState } from "./sync-plugin";
+import { loroSyncPluginKey, type LoroSyncPluginState } from "./sync-plugin-key";
 
 const loroCursorPluginKey = new PluginKey<{ awarenessUpdated: boolean }>(
   "loro-cursor",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
+export { LoroSyncPlugin } from "./sync-plugin";
 export {
-  LoroSyncPlugin,
   loroSyncPluginKey,
   type LoroSyncPluginProps,
   type LoroSyncPluginState,
-} from "./sync-plugin";
+} from "./sync-plugin-key";
 export {
   createNodeFromLoroObj,
   updateLoroToPmState,
@@ -21,12 +21,5 @@ export {
 } from "./lib";
 export { LoroCursorPlugin } from "./cursor-plugin";
 export { CursorAwareness } from "./awareness";
-export {
-  LoroUndoPlugin,
-  loroUndoPluginKey,
-  type LoroUndoPluginProps,
-  undo,
-  redo,
-  canUndo,
-  canRedo,
-} from "./undo-plugin";
+export { LoroUndoPlugin, undo, redo, canUndo, canRedo } from "./undo-plugin";
+export { loroUndoPluginKey, type LoroUndoPluginProps } from "./undo-plugin-key";

--- a/src/sync-plugin-key.ts
+++ b/src/sync-plugin-key.ts
@@ -1,0 +1,23 @@
+import type { ContainerID, LoroDoc, Subscription } from "loro-crdt";
+import { PluginKey } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+import type { LoroDocType, LoroNodeMapping } from "./lib";
+
+export const loroSyncPluginKey = new PluginKey<LoroSyncPluginState>(
+  "loro-sync",
+);
+
+export interface LoroSyncPluginProps {
+  doc: LoroDocType;
+  mapping?: LoroNodeMapping;
+  containerId?: ContainerID;
+}
+
+export interface LoroSyncPluginState extends LoroSyncPluginProps {
+  changedBy: "local" | "import" | "checkout";
+  mapping: LoroNodeMapping;
+  snapshot?: LoroDoc | null;
+  view?: EditorView;
+  containerId?: ContainerID;
+  docSubscription?: Subscription | null;
+}

--- a/src/sync-plugin.ts
+++ b/src/sync-plugin.ts
@@ -1,18 +1,6 @@
-import type {
-  ContainerID,
-  Cursor,
-  LoroDoc,
-  LoroEventBatch,
-  LoroMap,
-  Subscription,
-} from "loro-crdt";
+import type { Cursor, LoroEventBatch, LoroMap } from "loro-crdt";
 import { Fragment, Slice } from "prosemirror-model";
-import {
-  type EditorState,
-  Plugin,
-  PluginKey,
-  type StateField,
-} from "prosemirror-state";
+import { type EditorState, Plugin, type StateField } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
 import {
@@ -29,12 +17,13 @@ import {
   safeSetSelection,
   updateLoroToPmState,
 } from "./lib";
+import {
+  loroSyncPluginKey,
+  type LoroSyncPluginProps,
+  type LoroSyncPluginState,
+} from "./sync-plugin-key";
 import { configLoroTextStyle } from "./text-style";
-import { loroUndoPluginKey } from "./undo-plugin";
-
-export const loroSyncPluginKey = new PluginKey<LoroSyncPluginState>(
-  "loro-sync",
-);
+import { loroUndoPluginKey } from "./undo-plugin-key";
 
 type PluginTransactionType =
   | {
@@ -47,21 +36,6 @@ type PluginTransactionType =
       type: "update-state";
       state: Partial<LoroSyncPluginState>;
     };
-
-export interface LoroSyncPluginProps {
-  doc: LoroDocType;
-  mapping?: LoroNodeMapping;
-  containerId?: ContainerID;
-}
-
-export interface LoroSyncPluginState extends LoroSyncPluginProps {
-  changedBy: "local" | "import" | "checkout";
-  mapping: LoroNodeMapping;
-  snapshot?: LoroDoc | null;
-  view?: EditorView;
-  containerId?: ContainerID;
-  docSubscription?: Subscription | null;
-}
 
 export const LoroSyncPlugin = (props: LoroSyncPluginProps): Plugin => {
   return new Plugin({

--- a/src/undo-plugin-key.ts
+++ b/src/undo-plugin-key.ts
@@ -1,0 +1,18 @@
+import type { LoroDoc, UndoManager } from "loro-crdt";
+import { PluginKey } from "prosemirror-state";
+
+export const loroUndoPluginKey = new PluginKey<LoroUndoPluginState>(
+  "loro-undo",
+);
+
+export interface LoroUndoPluginProps {
+  doc: LoroDoc;
+  undoManager?: UndoManager;
+}
+
+export interface LoroUndoPluginState {
+  undoManager: UndoManager;
+  canUndo: boolean;
+  canRedo: boolean;
+  isUndoing: { current: boolean };
+}

--- a/src/undo-plugin.ts
+++ b/src/undo-plugin.ts
@@ -1,32 +1,22 @@
 import type { Cursor } from "loro-crdt";
-import { LoroDoc, UndoManager } from "loro-crdt";
+import { UndoManager } from "loro-crdt";
 import {
   type Command,
   EditorState,
   Plugin,
-  PluginKey,
   type StateField,
 } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import { convertPmSelectionToCursors } from "./cursor-plugin";
-import { loroSyncPluginKey, syncCursorsToPmSelection } from "./sync-plugin";
+import { syncCursorsToPmSelection } from "./sync-plugin";
+import { loroSyncPluginKey } from "./sync-plugin-key";
 import { configLoroTextStyle } from "./text-style";
+import {
+  loroUndoPluginKey,
+  type LoroUndoPluginProps,
+  type LoroUndoPluginState,
+} from "./undo-plugin-key";
 
-export interface LoroUndoPluginProps {
-  doc: LoroDoc;
-  undoManager?: UndoManager;
-}
-
-export const loroUndoPluginKey = new PluginKey<LoroUndoPluginState>(
-  "loro-undo",
-);
-
-interface LoroUndoPluginState {
-  undoManager: UndoManager;
-  canUndo: boolean;
-  canRedo: boolean;
-  isUndoing: { current: boolean };
-}
 type Cursors = { anchor: Cursor | null; focus: Cursor | null };
 export const LoroUndoPlugin = (props: LoroUndoPluginProps): Plugin => {
   const undoManager = props.undoManager || new UndoManager(props.doc, {});


### PR DESCRIPTION
Moves some code to fix the following "Circular dependencies" build warning. No runtime logic change.

Before:

```bash
❯ pnpm run build

src/index.ts → dist/index.js, dist/index.mjs...
(!) Circular dependencies
src/sync-plugin.ts -> src/cursor-plugin.ts -> src/sync-plugin.ts
src/sync-plugin.ts -> src/undo-plugin.ts -> src/sync-plugin.ts
created dist/index.js, dist/index.mjs in 127ms
```

After:

```bash
❯ pnpm run build

src/index.ts → dist/index.js, dist/index.mjs...
created dist/index.js, dist/index.mjs in 129ms
```