### PR TITLE
fix: export some types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export {
   type LoroContainer,
   type LoroType,
 } from "./lib";
-export type { CursorPluginOptions, CursorPresenceState } from "./cursor/common";
+export type { CursorPluginOptions, CursorPresenceState, CursorUser } from "./cursor/common";
 export { CursorEphemeralStore, LoroEphemeralCursorPlugin } from "./cursor/ephemeral";
 export { CursorAwareness, LoroCursorPlugin } from "./cursor/awareness";
 export { LoroUndoPlugin, undo, redo, canUndo, canRedo } from "./undo-plugin";


### PR DESCRIPTION
These types should be exported because they are used by other public APIs. 