### PR TITLE
doc: Document how more than one editor instance can be synced

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,17 @@ const editor = new EditorView(editorDom, {
 ```
 
 https://github.com/loro-dev/prosemirror/assets/18425020/d0f01760-b76c-43b5-b7f7-b0b224130d9d
+
+## Syncing more than one editor instance
+
+In case you want to sync multiple ProseMirror editor instances to the same Loro document, you can define for each ProseMirror editor the [Container ID](https://loro.dev/docs/advanced/cid) into which the editor's content will be stored:
+
+```ts
+const doc = new LoroDoc();
+const map = doc.getMap("<unique-id-per-editor-instance>");
+
+const plugins = [
+  LoroSyncPlugin({ doc, containerId: map.id }),
+  // see above for other plugins
+];
+```


### PR DESCRIPTION
It took me a while to figure out how can I sync more than one editor instance in the same Loro document. Thus I would document how this can be achieved.

## Background

I am working on an editor for learning materials. In this area, I need to be able to strongly define the structure of the document (e.g., exercises consist of exactly one task description and one solution // gaps are only allowed in gap-fill tasks, etc.), so I can't rely solely on ProseMirror. My idea is to develop a form-based editor where each rich-text element is a separate ProseMirror instance. Thus I need to be able to sync multiple ProseMirror instances in one Loro document.