### PR TITLE
fix: remove attributes in loro map

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -511,7 +511,7 @@ export function updateLoroMapAttributes(
 
   // remove all keys that are no longer in pAttrs
   for (const key of keys) {
-    pAttrs.delete(key);
+    attrs.delete(key);
   }
 }
 


### PR DESCRIPTION
changed removing target from prosemirror to loro map

fix #61 