### PR TITLE
feat(sync): Add checks when `containerId` is provided

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -75,9 +75,7 @@ export function updateLoroToPmState(
   containerId?: ContainerID,
 ) {
   const node = editorState.doc;
-  const map = containerId
-    ? (doc.getContainerById(containerId) as LoroMap<LoroNodeContainerType>)
-    : doc.getMap(ROOT_DOC_KEY);
+  const map = getContainer(doc, containerId);
 
   let isInit = false;
   if (map.get("nodeName") == null) {
@@ -92,6 +90,27 @@ export function updateLoroToPmState(
   } else {
     doc.commit({ origin: "loroSyncPlugin" });
   }
+}
+
+function getContainer(
+  doc: LoroDocType,
+  containerId?: ContainerID,
+): LoroMap<LoroNodeContainerType> {
+  if (containerId == null) return doc.getMap(ROOT_DOC_KEY);
+
+  const container = doc.getContainerById(containerId);
+
+  if (container == null) {
+    throw new Error(
+      `Container with ID ${containerId} not found. Maybe the container is not attached to the document yet.`,
+    );
+  }
+
+  if (!(container instanceof LoroMap)) {
+    throw new Error(`Container with ID ${containerId} is not a LoroMap`);
+  }
+
+  return container as LoroMap<LoroNodeContainerType>;
 }
 
 export function createNodeFromLoroObj(


### PR DESCRIPTION
I run into an issue providing a container ID of an detached container. With the implementation before I got an `Uncaught TypeError` since there is no type check whether `getContainerId()` returns a container so that `map.get()` cannot be called (see https://github.com/loro-dev/loro-prosemirror/blob/b2bcee50e81a1db120983771cbe30cba1adf9dd2/src/lib.ts#L78-L83). I took me a while to find the issue.

Thus I suggest to add some type checks when `containerId` is provided with appropriate error message. This should result in a better developer experience.

Note: Due to #66 I haven't checked my code.