### PR TITLE
chore: Format all files with "pnpm run format"

### DIFF
--- a/examples/stories/src/stories/Editor.stories.tsx
+++ b/examples/stories/src/stories/Editor.stories.tsx
@@ -4,10 +4,7 @@ import type { Meta, StoryFn } from "@storybook/react";
 import { Editor } from "./Editor";
 import { Cursor, LoroDoc, PeerID, VersionVector } from "loro-crdt";
 import { useEffect, useRef, useState, useCallback, useMemo } from "react";
-import {
-  CursorEphemeralStore,
-  LoroDocType,
-} from "loro-prosemirror";
+import { CursorEphemeralStore, LoroDocType } from "loro-prosemirror";
 import { DagViewComponent } from "./DagView";
 import type { ViewDagNode } from "./DagView";
 import { convertSyncStepsToNodes } from "./editor-history";
@@ -920,11 +917,16 @@ export const MultiOfflineSyncWithHistory = () => {
     const unsubscribers = stores.map(({ store, online }) =>
       store.subscribeLocalUpdates((bytes) => {
         if (!online) return;
-        if (isAOnline && store !== presenceA.current) presenceA.current.apply(bytes);
-        if (isBOnline && store !== presenceB.current) presenceB.current.apply(bytes);
-        if (isCOnline && store !== presenceC.current) presenceC.current.apply(bytes);
-        if (isDOnline && store !== presenceD.current) presenceD.current.apply(bytes);
-        if (isEOnline && store !== presenceE.current) presenceE.current.apply(bytes);
+        if (isAOnline && store !== presenceA.current)
+          presenceA.current.apply(bytes);
+        if (isBOnline && store !== presenceB.current)
+          presenceB.current.apply(bytes);
+        if (isCOnline && store !== presenceC.current)
+          presenceC.current.apply(bytes);
+        if (isDOnline && store !== presenceD.current)
+          presenceD.current.apply(bytes);
+        if (isEOnline && store !== presenceE.current)
+          presenceE.current.apply(bytes);
       }),
     );
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,4 @@ packages:
   - examples/*
 
 onlyBuiltDependencies:
-  - '@swc/core'
+  - "@swc/core"

--- a/src/cursor/awareness.ts
+++ b/src/cursor/awareness.ts
@@ -1,5 +1,9 @@
 import { Awareness, Cursor, type PeerID } from "loro-crdt";
-import { createCursorPlugin, type CursorPluginOptions, type CursorPresenceStore } from "./common";
+import {
+  createCursorPlugin,
+  type CursorPluginOptions,
+  type CursorPresenceStore,
+} from "./common";
 import { PluginKey } from "prosemirror-state";
 
 export class CursorAwareness extends Awareness<{
@@ -76,9 +80,7 @@ const loroCursorPluginKey = new PluginKey<{ presenceUpdated: boolean }>(
   "loro-cursor",
 );
 
-const awarenessAdapter = (
-  awareness: CursorAwareness,
-): CursorPresenceStore => ({
+const awarenessAdapter = (awareness: CursorAwareness): CursorPresenceStore => ({
   getAll: () => awareness.getAll(),
   getLocal: () => {
     const state = awareness.getLocal();
@@ -105,8 +107,4 @@ export const LoroCursorPlugin = (
   awareness: CursorAwareness,
   options: CursorPluginOptions,
 ) =>
-  createCursorPlugin(
-    loroCursorPluginKey,
-    awarenessAdapter(awareness),
-    options,
-  );
+  createCursorPlugin(loroCursorPluginKey, awarenessAdapter(awareness), options);

--- a/src/cursor/common.ts
+++ b/src/cursor/common.ts
@@ -20,7 +20,10 @@ import {
   type LoroNodeMapping,
   WEAK_NODE_TO_LORO_CONTAINER_MAPPING,
 } from "../lib";
-import { loroSyncPluginKey, type LoroSyncPluginState } from "../sync-plugin-key";
+import {
+  loroSyncPluginKey,
+  type LoroSyncPluginState,
+} from "../sync-plugin-key";
 
 export type CursorUser = { name: string; color: string };
 export type CursorPresenceState = {
@@ -277,11 +280,11 @@ export function convertPmSelectionToCursors(
     selection.head == selection.anchor
       ? anchor
       : absolutePositionToCursor(
-        pmRootNode,
-        selection.head,
-        loroState.doc as LoroDocType,
-        loroState.mapping,
-      );
+          pmRootNode,
+          selection.head,
+          loroState.doc as LoroDocType,
+          loroState.mapping,
+        );
   return { anchor, focus };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,15 @@ export {
   type LoroContainer,
   type LoroType,
 } from "./lib";
-export type { CursorPluginOptions, CursorPresenceState, CursorUser } from "./cursor/common";
-export { CursorEphemeralStore, LoroEphemeralCursorPlugin } from "./cursor/ephemeral";
+export type {
+  CursorPluginOptions,
+  CursorPresenceState,
+  CursorUser,
+} from "./cursor/common";
+export {
+  CursorEphemeralStore,
+  LoroEphemeralCursorPlugin,
+} from "./cursor/ephemeral";
 export { CursorAwareness, LoroCursorPlugin } from "./cursor/awareness";
 export { LoroUndoPlugin, undo, redo, canUndo, canRedo } from "./undo-plugin";
 export { loroUndoPluginKey, type LoroUndoPluginProps } from "./undo-plugin-key";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -252,9 +252,7 @@ function nodeMarksToAttributes(marks: readonly Mark[]): {
   return pattrs;
 }
 
-function valueToAttrs(
-  value: Value | Attrs | null | undefined,
-): Attrs | null {
+function valueToAttrs(value: Value | Attrs | null | undefined): Attrs | null {
   if (
     value != null &&
     typeof value === "object" &&

--- a/src/sync-plugin.ts
+++ b/src/sync-plugin.ts
@@ -27,15 +27,15 @@ import { loroUndoPluginKey } from "./undo-plugin-key";
 
 type PluginTransactionType =
   | {
-    type: "doc-changed";
-  }
+      type: "doc-changed";
+    }
   | {
-    type: "non-local-updates";
-  }
+      type: "non-local-updates";
+    }
   | {
-    type: "update-state";
-    state: Partial<LoroSyncPluginState>;
-  };
+      type: "update-state";
+      state: Partial<LoroSyncPluginState>;
+    };
 
 export const LoroSyncPlugin = (props: LoroSyncPluginProps): Plugin => {
   return new Plugin({
@@ -103,7 +103,7 @@ export const LoroSyncPlugin = (props: LoroSyncPluginProps): Plugin => {
     view: (view: EditorView) => {
       const timeoutId = setTimeout(() => init(view), 0);
       return {
-        update: (_view: EditorView, _prevState: EditorState) => { },
+        update: (_view: EditorView, _prevState: EditorState) => {},
         destroy: () => {
           clearTimeout(timeoutId);
         },
@@ -138,8 +138,8 @@ function init(view: EditorView) {
 
   const innerDoc = state.containerId
     ? (state.doc.getContainerById(
-      state.containerId,
-    ) as LoroMap<LoroNodeContainerType>)
+        state.containerId,
+      ) as LoroMap<LoroNodeContainerType>)
     : (state.doc as LoroDocType).getMap(ROOT_DOC_KEY);
 
   const mapping: LoroNodeMapping = new Map();
@@ -189,8 +189,8 @@ function updateNodeOnLoroEvent(view: EditorView, event: LoroEventBatch) {
     view.state.schema,
     state.containerId
       ? (state.doc.getContainerById(
-        state.containerId,
-      ) as LoroMap<LoroNodeContainerType>)
+          state.containerId,
+        ) as LoroMap<LoroNodeContainerType>)
       : (state.doc as LoroDocType).getMap(ROOT_DOC_KEY),
     mapping,
   );


### PR DESCRIPTION
I noticed in #67 that some files aren't formatted with `prettier`, see: 
<img width="906" height="386" alt="2025-12-28-222821_906x386_scrot" src="https://github.com/user-attachments/assets/7802aba2-6a29-4e8e-b01f-28b918637460" />

For avoiding unnecessary format changes in further PRs (my IDE is setup to run prettier on every save), this PR updates all formats. 
