### PR TITLE
fix: pass Unix seconds (not milliseconds) to commit timestamp

### DIFF
--- a/src/sync-plugin.ts
+++ b/src/sync-plugin.ts
@@ -83,7 +83,7 @@ export const LoroSyncPlugin = (props: LoroSyncPluginProps): Plugin => {
             state = { ...state, ...meta.state };
             state.doc.commit({
               origin: "sys:init",
-              timestamp: Date.now(),
+              timestamp: Math.floor(Date.now() / 1000),
             });
             break;
           default:


### PR DESCRIPTION
Loro expects Unix seconds, but Date.now() returns milliseconds.
On loro-crdt@1.10.2 (the current locked version) the explicit timestamp is ignored, but on >=1.10.6 it's respected. This is causing sync-plugin commit millisecond timestamps, which leads to errors downstream