### PR TITLE
fix: correct presence-cursor mapping for nested containers, hard breaks, and remote edits

### DIFF
--- a/src/cursor/common.ts
+++ b/src/cursor/common.ts
@@ -223,7 +223,13 @@ function createDecorations(
       doc as LoroDocType,
       loroState.mapping,
     );
-    d.push(Decoration.widget(focus, createCursor(peer as PeerID)));
+    d.push(
+      Decoration.widget(focus, createCursor(peer as PeerID), {
+        // Stable key per peer so ProseMirror reuses the widget DOM across
+        // redraws instead of recreating it (which makes the caret flash).
+        key: `loro-cursor-${peer}`,
+      }),
+    );
     if (!cursorEq(cursor.anchor, cursor.focus)) {
       const [anchor, anchorCursorUpdate] = cursorToAbsolutePosition(
         cursor.anchor,
@@ -327,7 +333,13 @@ function absolutePositionToCursor(
     const child = children.get(childIndex);
     childIndex += 1;
     if (child instanceof LoroText) {
-      return child.getCursor(index);
+      // A single block can hold more than one LoroText leaf (e.g. text split
+      // by a hard break). Only bind here if the offset falls within this leaf;
+      // otherwise consume its length and continue to the next child.
+      if (index <= child.length) {
+        return child.getCursor(index);
+      }
+      index -= child.length;
     } else {
       if (index == 0) {
         // This happens when user selects an image or a horizontal rule
@@ -407,7 +419,12 @@ export function cursorToAbsolutePosition(
       loroNode = loroNode.parent()?.parent() as LoroNode | undefined;
       index += 1;
     } else {
-      throw new Error("Unreachable code");
+      // We have walked out of the editor's own subtree. This happens when the
+      // editor is bound to a nested container (`containerId`) rather than the
+      // doc root: the walk climbs past the bound node into the surrounding
+      // document, whose children are not a ProseMirror child list. Stop here
+      // and return the position accumulated within the editor subtree.
+      break;
     }
   }
 

--- a/src/sync-plugin.ts
+++ b/src/sync-plugin.ts
@@ -1,6 +1,11 @@
 import type { Cursor, LoroEventBatch, LoroMap } from "loro-crdt";
 import { Fragment, Slice } from "prosemirror-model";
-import { type EditorState, Plugin, type StateField } from "prosemirror-state";
+import {
+  type EditorState,
+  Plugin,
+  type StateField,
+  TextSelection,
+} from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
 import {
@@ -184,6 +189,13 @@ function updateNodeOnLoroEvent(view: EditorView, event: LoroEventBatch) {
   }
 
   const mapping = state.mapping;
+  // Capture the local selection as stable Loro cursors BEFORE clearing changed
+  // nodes, which mutates the mapping this conversion relies on.
+  const { anchor, focus } = convertPmSelectionToCursors(
+    view.state.doc,
+    view.state.selection,
+    state,
+  );
   clearChangedNodes(state.doc as LoroDocType, event, mapping);
   const node = createNodeFromLoroObj(
     view.state.schema,
@@ -193,11 +205,6 @@ function updateNodeOnLoroEvent(view: EditorView, event: LoroEventBatch) {
         ) as LoroMap<LoroNodeContainerType>)
       : (state.doc as LoroDocType).getMap(ROOT_DOC_KEY),
     mapping,
-  );
-  const { anchor, focus } = convertPmSelectionToCursors(
-    view.state.doc,
-    view.state.selection,
-    state,
   );
 
   let tr = view.state.tr.replace(
@@ -209,14 +216,29 @@ function updateNodeOnLoroEvent(view: EditorView, event: LoroEventBatch) {
   tr.setMeta(loroSyncPluginKey, {
     type: "non-local-updates",
   });
-  view.dispatch(tr);
 
-  if (anchor == null) {
-    return;
+  // Restore the local selection in the SAME transaction as the content
+  // replacement, so the caret does not visibly jump to the document boundary
+  // (and back a tick later) when a remote peer edits elsewhere. Cursors
+  // resolved against the rebuilt doc can be out of bounds if presence arrives
+  // ahead of content, so bounds-check before applying.
+  if (anchor != null) {
+    const anchorPos = cursorToAbsolutePosition(anchor, state.doc, mapping)[0];
+    const focusPos =
+      focus && cursorToAbsolutePosition(focus, state.doc, mapping)[0];
+    const docSize = tr.doc.content.size;
+    if (
+      anchorPos >= 0 &&
+      anchorPos <= docSize &&
+      (focusPos == null || (focusPos >= 0 && focusPos <= docSize))
+    ) {
+      const $anchor = tr.doc.resolve(anchorPos);
+      const $focus = focusPos != null ? tr.doc.resolve(focusPos) : $anchor;
+      tr.setSelection(TextSelection.between($anchor, $focus));
+    }
   }
-  setTimeout(() => {
-    syncCursorsToPmSelection(view, anchor, focus);
-  });
+
+  view.dispatch(tr);
 }
 
 /**

--- a/tests/cursor.test.ts
+++ b/tests/cursor.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "vitest";
+
+import { LoroDoc, LoroMap } from "loro-crdt";
+import { Schema } from "prosemirror-model";
+import { EditorState, TextSelection } from "prosemirror-state";
+
+import {
+  CHILDREN_KEY,
+  updateLoroToPmState,
+  type LoroDocType,
+  type LoroNodeMapping,
+} from "../src/lib";
+import {
+  convertPmSelectionToCursors,
+  cursorToAbsolutePosition,
+} from "../src/cursor/common";
+
+// A schema with an inline hard break, so a single paragraph can contain more
+// than one LoroText leaf (e.g. "abc" <break> "de"), as happens after
+// shift+enter. The default test schema has no inline leaf, so this case was
+// never exercised.
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block*" },
+    paragraph: { content: "inline*", group: "block" },
+    hardBreak: { inline: true, group: "inline", selectable: false },
+    text: { group: "inline" },
+  },
+  marks: {},
+});
+
+function editorStateFrom(content: unknown): EditorState {
+  return EditorState.create({ doc: schema.nodeFromJSON(content), schema });
+}
+
+describe("absolutePositionToCursor across multiple text leaves", () => {
+  test("a single text run still round-trips (sanity)", () => {
+    const editorState = editorStateFrom({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "abc" }] },
+      ],
+    });
+    const doc: LoroDocType = new LoroDoc();
+    const mapping: LoroNodeMapping = new Map();
+    updateLoroToPmState(doc, mapping, editorState);
+    const loroState = { doc, mapping } as never;
+
+    const target = 2; // "a|bc"
+    const { anchor } = convertPmSelectionToCursors(
+      editorState.doc,
+      TextSelection.create(editorState.doc, target),
+      loroState,
+    );
+    expect(anchor).toBeTruthy();
+    const [pos] = cursorToAbsolutePosition(anchor!, doc, mapping);
+    expect(pos).toBe(target);
+  });
+
+  test("a caret in the second run (after a hard break) round-trips", () => {
+    const editorState = editorStateFrom({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "abc" },
+            { type: "hardBreak" },
+            { type: "text", text: "de" },
+          ],
+        },
+      ],
+    });
+    const doc: LoroDocType = new LoroDoc();
+    const mapping: LoroNodeMapping = new Map();
+    updateLoroToPmState(doc, mapping, editorState);
+    const loroState = { doc, mapping } as never;
+
+    // Absolute PM positions: paragraph opens at 0, "abc" = 1..4, the hardBreak
+    // leaf occupies 4..5, "de" = 5..7. A caret between "d" and "e" is pos 6.
+    // Before the fix, absolutePositionToCursor returned a cursor on the FIRST
+    // text leaf ("abc") with an out-of-range offset, so this did not round-trip.
+    const target = 6;
+    const { anchor } = convertPmSelectionToCursors(
+      editorState.doc,
+      TextSelection.create(editorState.doc, target),
+      loroState,
+    );
+    expect(anchor).toBeTruthy();
+    const [pos] = cursorToAbsolutePosition(anchor!, doc, mapping);
+    expect(pos).toBe(target);
+  });
+});
+
+describe("cursorToAbsolutePosition with a nested editor container", () => {
+  test("resolves a position when the bound container is not the doc root", () => {
+    const doc: LoroDocType = new LoroDoc();
+    // Mimic an app that stores the rich-text body as a nested container:
+    // root > entity > body, binding the editor to `body` rather than the doc
+    // root. The parent-walk then climbs past the editor's own subtree.
+    const root = doc.getMap("data");
+    const entity = root.setContainer("entity", new LoroMap());
+    const body = entity.setContainer("body", new LoroMap());
+    doc.commit();
+
+    const editorState = editorStateFrom({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "Hello" }] },
+      ],
+    });
+    const mapping: LoroNodeMapping = new Map();
+    updateLoroToPmState(doc, mapping, editorState, body.id);
+
+    // Build a cursor 3 chars into the text ("Hel|lo").
+    const bodyChildren = body.get(CHILDREN_KEY) as never as {
+      get(i: number): unknown;
+    };
+    const paragraph = bodyChildren.get(0) as LoroMap;
+    const paragraphChildren = paragraph.get(CHILDREN_KEY) as never as {
+      get(i: number): { getCursor(pos: number): never };
+    };
+    const text = paragraphChildren.get(0);
+    const cursor = text.getCursor(3);
+
+    // Before the fix this threw `Error: Unreachable code`, because the walk
+    // assumed it would always terminate at a parentless root container.
+    const [pos] = cursorToAbsolutePosition(cursor, doc, mapping);
+    expect(pos).toBe(4); // paragraph opens at 0, "Hel|" -> absolute pos 4
+  });
+});


### PR DESCRIPTION
Disclaimer: This PR was written with the help of AI. I'm not that familiar with the details of this repository yet, but the changes seem to solve the issues mentioned below.

--- 

Four fixes to selection/cursor handling, each independent:

1. cursorToAbsolutePosition: stop the parent-walk instead of throwing "Unreachable code" when the editor is bound to a nested container (containerId) rather than the doc root. The walk climbed past the bound node into the surrounding document and threw.

2. absolutePositionToCursor: walk across multiple LoroText leaves in one block (e.g. text split by a hard break) instead of always binding to the first leaf with a possibly out-of-range offset.

3. Cursor widget decorations get a stable per-peer key so ProseMirror reuses the DOM across redraws instead of recreating it (caret flashing).

4. updateNodeOnLoroEvent: restore the local selection in the same transaction as the content replacement (bounds-checked) instead of a deferred setTimeout, so the caret does not jump to the doc boundary when a remote peer edits elsewhere. Selection is also captured before clearChangedNodes mutates the mapping it depends on.

Adds tests/cursor.test.ts covering fixes 1 and 2.