### PR TITLE
fix: treat marks with unset inclusive as inclusive when configuring text style

### DIFF
--- a/src/text-style.ts
+++ b/src/text-style.ts
@@ -9,7 +9,9 @@ function getLoroTextStyle(schema: Schema): {
   return Object.fromEntries(
     Object.entries(schema.marks).map(([markName, markType]) => [
       markName,
-      { expand: markType.spec.inclusive ? "after" : "none" },
+      // ProseMirror marks are inclusive unless the spec says otherwise, so
+      // only an explicit `inclusive: false` should map to "none".
+      { expand: markType.spec.inclusive !== false ? "after" : "none" },
     ]),
   );
 }

--- a/tests/text-style.test.ts
+++ b/tests/text-style.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+
+import { LoroDoc } from "loro-crdt";
+import { Schema } from "prosemirror-model";
+
+import { configLoroTextStyle } from "../src/text-style";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block*" },
+    paragraph: { content: "inline*", group: "block" },
+    text: { group: "inline" },
+  },
+  marks: {
+    // Like most real-world marks (bold, italic, code, ...), `inclusive` is
+    // left unset, which ProseMirror treats as `true`.
+    bold: {},
+    inclusiveMark: { inclusive: true },
+    exclusiveMark: { inclusive: false },
+  },
+});
+
+describe("configLoroTextStyle", () => {
+  test("marks with unset inclusive expand like ProseMirror does", () => {
+    const doc = new LoroDoc();
+    configLoroTextStyle(doc, schema);
+
+    const text = doc.getText("text");
+    text.insert(0, "hello");
+    text.mark({ start: 0, end: 5 }, "bold", true);
+    // ProseMirror extends default-inclusive marks over text typed at their
+    // end, so Loro must do the same or the two sides diverge on every
+    // keystroke of styled typing.
+    text.insert(5, "!");
+    expect(text.toDelta()).toEqual([
+      { insert: "hello!", attributes: { bold: true } },
+    ]);
+  });
+
+  test("explicitly inclusive marks expand", () => {
+    const doc = new LoroDoc();
+    configLoroTextStyle(doc, schema);
+
+    const text = doc.getText("text");
+    text.insert(0, "hello");
+    text.mark({ start: 0, end: 5 }, "inclusiveMark", true);
+    text.insert(5, "!");
+    expect(text.toDelta()).toEqual([
+      { insert: "hello!", attributes: { inclusiveMark: true } },
+    ]);
+  });
+
+  test("explicitly exclusive marks do not expand", () => {
+    const doc = new LoroDoc();
+    configLoroTextStyle(doc, schema);
+
+    const text = doc.getText("text");
+    text.insert(0, "hello");
+    text.mark({ start: 0, end: 5 }, "exclusiveMark", true);
+    text.insert(5, "!");
+    expect(text.toDelta()).toEqual([
+      { insert: "hello", attributes: { exclusiveMark: true } },
+      { insert: "!" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

`configLoroTextStyle` maps a mark's expand behavior with `markType.spec.inclusive ? "after" : "none"`. But ProseMirror's [`MarkSpec.inclusive`](https://prosemirror.net/docs/ref/#model.MarkSpec.inclusive) **defaults to `true` when unset**, and mainstream marks (Tiptap's bold, italic, strike, code, ...) never set it. The truthiness check maps "unset" to `"none"`, so for every default-inclusive mark ProseMirror extends the mark over text typed at its end while Loro does not — the two sides of the binding permanently disagree about mark boundaries.

The practical cost: every character typed while extending a bold/italic/code run lands at the run's end, so on every such keystroke the PM document and the Loro doc diverge and the binding has to emit extra style ops to repair the difference. Those redundant mark ops leave style anchors behind in the container state forever, so heavily edited styled paragraphs get permanently slower to read.

## Fix

```ts
{ expand: markType.spec.inclusive !== false ? "after" : "none" }
```

Only an explicit `inclusive: false` now maps to `"none"`, matching ProseMirror's documented semantics.

## Validation

Added `tests/text-style.test.ts` covering the three cases (unset, explicitly `true`, explicitly `false`); the unset case fails without this change. `pnpm test`, `pnpm lint`, and `pnpm check-format` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQw7nfh6KaUhQy6ZQUZwMm