### PR TITLE
fix: stop emitting a delete op for attributes that are already absent

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -594,7 +594,7 @@ export function updateLoroMapAttributes(
       if (!equalityDeep(attrs.get(key), value)) {
         attrs.set(key, value);
       }
-    } else {
+    } else if (keys.has(key)) {
       attrs.delete(key);
     }
     keys.delete(key);

--- a/tests/attributes.test.ts
+++ b/tests/attributes.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "vitest";
+
+import { LoroDoc, type VersionVector } from "loro-crdt";
+import { Schema } from "prosemirror-model";
+
+import {
+  ROOT_DOC_KEY,
+  updateLoroToPmState,
+  type LoroDocType,
+  type LoroNodeMapping,
+} from "../src/lib";
+
+import { createEditorState } from "./utils";
+
+const nullableAttrSchema = new Schema({
+  nodes: {
+    doc: { content: "block*" },
+    paragraph: {
+      attrs: { checked: { default: null } },
+      content: "inline*",
+      group: "block",
+    },
+    text: { group: "inline" },
+  },
+});
+
+function opsSince(doc: LoroDoc, vv: VersionVector) {
+  return doc
+    .exportJsonUpdates(vv)
+    .changes.flatMap((change) => change.ops)
+    .map((op) => op.content);
+}
+
+function withChecked(checked: boolean | null) {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        attrs: { checked },
+        content: [{ type: "text", text: "Hello" }],
+      },
+    ],
+  };
+}
+
+describe("attributes", () => {
+  test("re-syncing an unchanged doc with null attributes emits no ops", () => {
+    const loroDoc: LoroDocType = new LoroDoc();
+    const mapping: LoroNodeMapping = new Map();
+
+    updateLoroToPmState(
+      loroDoc,
+      mapping,
+      createEditorState(nullableAttrSchema, withChecked(null)),
+    );
+    const version = loroDoc.version();
+
+    updateLoroToPmState(
+      loroDoc,
+      mapping,
+      createEditorState(nullableAttrSchema, withChecked(null)),
+    );
+
+    expect(opsSince(loroDoc, version)).toEqual([]);
+  });
+
+  test("an attribute set back to null is removed", () => {
+    const loroDoc: LoroDocType = new LoroDoc();
+    const mapping: LoroNodeMapping = new Map();
+
+    updateLoroToPmState(
+      loroDoc,
+      mapping,
+      createEditorState(nullableAttrSchema, withChecked(true)),
+    );
+    updateLoroToPmState(
+      loroDoc,
+      mapping,
+      createEditorState(nullableAttrSchema, withChecked(null)),
+    );
+
+    expect(loroDoc.toJSON()[ROOT_DOC_KEY].children[0].attributes).toEqual({});
+  });
+});


### PR DESCRIPTION
When a ProseMirror schema declares an attribute with `default: null`, `updateLoroMapAttributes` calls `attrs.delete(key)` on every sync even if the key was never written to the Loro map, and `LoroMap.delete` records an op whether or not the key exists. The visible symptom: every editor transaction over such a node produces an empty Loro change, which between two peers becomes an endless idle back-and-forth of updates. It can also lose data, since the spurious delete is a real concurrent op — if peer A sets `checked: true` while peer B types anywhere, B's delete can win the merge and silently revert the attribute, leaving it gone on both peers. Fix: guard the delete with the key set the function already builds from `attrs.keys()`, so a null attribute that's actually in the map still gets removed and one that was never there produces no op. Added a test that fails on main with `[{ type: 'delete', key: 'checked' }]`, plus one for the non-null → null case to make sure the real delete path still works.
